### PR TITLE
Add match for nflxso.net

### DIFF
--- a/server.py
+++ b/server.py
@@ -45,7 +45,7 @@ class BlockNetflixAAAAResolver(object):
             return False
         penultimateDomainPart = parts[-2]
 
-        return query.type == dns.AAAA and penultimateDomainPart in (b'netflix', b'nflximg', b'nflxext', b'nflxvideo')
+        return query.type == dns.AAAA and penultimateDomainPart in (b'netflix', b'nflximg', b'nflxext', b'nflxvideo', b'nflxso')
 
     def query(self, query, timeout=None):
         if self.__shouldBlock(query):


### PR DESCRIPTION
Netflix is using a new domain, nflxso.net.
Queries look like this - occ-0-70-92.1.nflxso.net.